### PR TITLE
メールアドレスとパスワードを使用した認証機能の実装

### DIFF
--- a/app/models/auth.ts
+++ b/app/models/auth.ts
@@ -1,0 +1,19 @@
+import { EmailOtpType } from "@supabase/supabase-js";
+
+/**
+ * ログイン処理のクエリパラメータの型定義
+ */
+export type SignInQueryParams = {
+  /**
+   * トークンハッシュ値
+   */
+  tokenHash: string | null;
+  /**
+   * 認証のタイプ
+   */
+  type: EmailOtpType | null;
+  /**
+   * リダイレクト先URL
+   */
+  nextUrl: string;
+};

--- a/app/routes/auth.confirm/route.tsx
+++ b/app/routes/auth.confirm/route.tsx
@@ -1,0 +1,33 @@
+import { LoaderFunctionArgs, redirect } from "@remix-run/node";
+import { EmailOtpType } from "@supabase/supabase-js";
+import { supabaseClient } from "~/services/supabase.server";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+
+  // クエリパラメータから必要な情報を取得
+  const token_hash = url.searchParams.get("token_hash");
+  const type = url.searchParams.get("type") as EmailOtpType | null;
+  const next = url.searchParams.get("next") ?? "/";
+
+  // リダイレクト先のURLがスラッシュで始まる場合はそのまま使用し、そうでなければルートページを設定
+  const redirectTo = next.startsWith("/") ? next : "/";
+
+  if (token_hash && type) {
+    const { supabase } = supabaseClient(request);
+
+    // Supabaseでトークンハッシュを使用したサインインを実行
+    const { error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash,
+    });
+
+    if (!error) {
+      // TODO:: ログイン処理(セッションへのユーザ情報の保存など)を施してからホームに遷移させる
+      return redirect(redirectTo);
+    }
+  }
+
+  // エラー画面にリダイレクト
+  return redirect("/error");
+};

--- a/app/routes/auth.confirm/route.tsx
+++ b/app/routes/auth.confirm/route.tsx
@@ -13,21 +13,22 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   // リダイレクト先のURLがスラッシュで始まる場合はそのまま使用し、そうでなければルートページを設定
   const redirectTo = next.startsWith("/") ? next : "/";
 
-  if (token_hash && type) {
-    const { supabase } = supabaseClient(request);
-
-    // Supabaseでトークンハッシュを使用したサインインを実行
-    const { error } = await supabase.auth.verifyOtp({
-      type,
-      token_hash,
-    });
-
-    if (!error) {
-      // TODO:: ログイン処理(セッションへのユーザ情報の保存など)を施してからホームに遷移させる
-      return redirect(redirectTo);
-    }
+  if (!token_hash || !type) {
+    return redirect("/error");
   }
 
-  // エラー画面にリダイレクト
-  return redirect("/error");
+  const { supabase } = supabaseClient(request);
+
+  // Supabaseでトークンハッシュを使用したサインインを実行
+  const { error } = await supabase.auth.verifyOtp({
+    type,
+    token_hash,
+  });
+
+  if (error) {
+    return redirect("/error");
+  }
+
+  // TODO:: ログイン処理(セッションへのユーザ情報の保存など)を施してからホームに遷移させる
+  return redirect(redirectTo);
 };

--- a/app/routes/auth.signin/route.tsx
+++ b/app/routes/auth.signin/route.tsx
@@ -4,8 +4,13 @@ import { supabaseClient } from "~/services/supabase.server";
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { supabase, headers } = supabaseClient(request);
 
-  // Supabase で匿名ログインを実行
-  const { error } = await supabase.auth.signInAnonymously();
+  const formData = await request.formData();
+
+  // Supabase でメール&パスワードログインを実行
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: formData.get("email")?.toString() ?? "",
+    password: formData.get("password")?.toString() ?? "",
+  });
 
   if (error) {
     return { error: error.message };

--- a/app/routes/auth.signup/route.tsx
+++ b/app/routes/auth.signup/route.tsx
@@ -1,0 +1,26 @@
+import { type ActionFunctionArgs, redirect } from "@remix-run/node";
+import { supabaseClient } from "~/services/supabase.server";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { supabase, headers } = supabaseClient(request);
+
+  const formData = await request.formData();
+
+  // Supabase でサインアップを実行
+  const { data, error } = await supabase.auth.signUp({
+    email: formData.get("email")?.toString() ?? "",
+    password: formData.get("password")?.toString() ?? "",
+  });
+
+  if (error) {
+    console.error(error);
+    return redirect("/error", {
+      headers,
+    });
+  }
+
+  // TODO:: data変数からセッションを取り出してサインイン状態を保持する処理を記述する
+  return redirect("/welcome", {
+    headers,
+  });
+};

--- a/app/routes/auth.signup/route.tsx
+++ b/app/routes/auth.signup/route.tsx
@@ -13,10 +13,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   });
 
   if (error) {
-    console.error(error);
-    return redirect("/error", {
-      headers,
-    });
+    return { error: error.message };
   }
 
   // TODO:: data変数からセッションを取り出してサインイン状態を保持する処理を記述する

--- a/app/routes/login/route.tsx
+++ b/app/routes/login/route.tsx
@@ -1,4 +1,4 @@
-import { Form } from "@remix-run/react";
+import { Form, Link } from "@remix-run/react";
 
 export default function LoginRoute() {
   return (
@@ -6,8 +6,16 @@ export default function LoginRoute() {
       <h1 className="mb-1">ログインページ</h1>
       <p>ログイン方法を二つ用意する</p>
       <Form action="/auth/signin" method="post">
+        <input name="email" type="email" placeholder="sample@example.com" />
+        <input name="password" type="password" placeholder="パスワード" />
+        <input
+          name="password_confirm"
+          type="password"
+          placeholder="パスワード(確認)"
+        />
         <button type="submit">ログイン</button>
       </Form>
+      <Link to={"/signup"}>新規登録</Link>
     </main>
   );
 }

--- a/app/routes/signup/route.tsx
+++ b/app/routes/signup/route.tsx
@@ -1,0 +1,15 @@
+import { Form } from "@remix-run/react";
+
+export default function SignupRoute() {
+  return (
+    <main className="p-6">
+      <h1 className="mb-1">サインアップページ</h1>
+      <p>メールアドレス&パスワード認証用のフォーム</p>
+      <Form action="/auth/signup" method="post">
+        <input name="email" type="email" placeholder="sample@example.com" />
+        <input name="password" type="password" placeholder="パスワード" />
+        <button type="submit">登録</button>
+      </Form>
+    </main>
+  );
+}

--- a/app/routes/welcome/route.tsx
+++ b/app/routes/welcome/route.tsx
@@ -1,0 +1,8 @@
+export default function WelcomeRoute() {
+  return (
+    <>
+      <h1>認証用のメールを送信しました。</h1>
+      <p>メールを確認してください</p>
+    </>
+  );
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -92,7 +92,7 @@ enabled = true
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 additional_redirect_urls = ["https://127.0.0.1:3000"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
@@ -117,7 +117,8 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = false
+# NOTE: 認証メール送信機能を使用する場合は trueを設定
+enable_confirmations = true
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
@@ -136,6 +137,11 @@ max_frequency = "1s"
 # [auth.email.template.invite]
 # subject = "You have been invited"
 # content_path = "./supabase/templates/invite.html"
+
+# NOTE: サインアップ時の認証メールの設定
+[auth.email.template.confirmation]
+subject = "メールアドレスを承認してください"
+content_path = "./supabase/templates/confirmation.html"
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,0 +1,8 @@
+<h2>Confirm your signup</h2>
+
+<p>Follow this link to confirm your user:</p>
+<p>
+  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email"
+    >Confirm your email</a
+  >
+</p>


### PR DESCRIPTION
refs:
- https://github.com/badpuku/pukusapo/issues/21

## 概要
メールアドレスと、パスワードを使用した認証機能を実装しました  
サインアップ時にはメールアドレス宛に認証メールが届き、メール内のリンクをクリックするとユーザが認証済みになり、サインインできるようになります

## やっていないこと
- エラー発生時の遷移先画面の作成
- フォームのバリデーションチェックの実装
- ログイン後のセッションの保存処理の実装

## レビュー観点
- メールアドレスとパスワードを用いた認証機能が実装されていること
- ファイル分けが適切であること

## メールの承認方法
- ローカルで送信された認証メールについては、下記のURLから確認することができます
  - http://127.0.0.1:54324