### PR TITLE
authスキーマのusersテーブルをpublicスキーマに複製する設定を作成

### DIFF
--- a/supabase/migrations/20250111155406_initialize_auth.sql
+++ b/supabase/migrations/20250111155406_initialize_auth.sql
@@ -1,0 +1,43 @@
+-- public スキーマにusersテーブルを作成する
+create table public.users (
+  id uuid primary key references auth.users on delete cascade,
+  email text not NULL,
+  first_name text,
+  last_name text
+);
+
+-- users テーブルへのRLSの設定
+alter table public.users
+  enable row level security;
+
+-- ロールがauthenticatedのユーザのみ、ユーザの一覧取得を可能とするポリシー
+create policy "Allow select for all authenticated users."
+  on public.users for select using (
+    auth.role() = 'authenticated'
+  );
+
+-- ユーザ自身が登録情報を変更する際に、操作者と変更対象データのIDが一致している確認するポリシー
+create policy "Allow update for users themselves."
+  on public.users for update using (
+    auth.uid() = id
+  );
+
+
+-- auth.users をコピーする関数の定義
+create function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.users (id, email)
+  values (new.id, new.email);
+  return new;
+end;
+$$;
+
+-- 作成した関数を実行するトリガーを作成
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute procedure public.handle_new_user();


### PR DESCRIPTION
refs:
- https://github.com/badpuku/pukusapo/issues/22

## 概要
authスキーマに作成されたユーザ情報をpublicスキーマにも登録するための設定を行いました
- publicスキーマにusersテーブルを作成
- auth.usersにデータが登録されたときに、public.usersにもデータが登録されるように関数を作成
- auth.usersに上記の関数が実行されるトリガーを設定
- ユーザ削除時に、public.usersからもデータが削除されるように設定

## やっていないこと
- public.usersテーブルのカラムの選定
- 初期ユーザ登録のseedファイル作成
- public.usersのポリシー設定 (最低限のものだけ設定済)

## レビュー観点
- ユーザ登録時にpublic.usersにも情報が登録されていること
- ユーザ削除時にpublic.usersからもデータが削除されていること
- 両テーブルの同期データの整合性がとれていること

## マイグレーションファイルの反映方法
- 現在格納されているデータは削除されてしまうので、注意してください  
  [参考ドキュメント](https://supabase.com/docs/guides/local-development/overview)
- supabaseのローカル環境をリセットします
  - `npx supabase reset`